### PR TITLE
fix: hoc pattern example

### DIFF
--- a/pages/patterns/react-patterns/higher-order-component.mdx
+++ b/pages/patterns/react-patterns/higher-order-component.mdx
@@ -65,7 +65,7 @@ We can import the `withStyles` HOC, and wrap any component that needs styling.
 ```js
 import { withStyles } from "./hoc/withStyles";
 
-const Text = () => <p style={{ fontFamily: "Inter" }}>Hello world!</p>;
+const Text = (props) => <p style={{ fontFamily: "Inter", ...props.style }}>Hello world!</p>;
 const StyledText = withStyles(Text);
 ```
 


### PR DESCRIPTION
```js
export function withStyles(Component) {
  return (props) => {
    const style = {
      color: "red",
      fontSize: "1em",
      // Merge props
      ...props.style,
    };

    return <Component {...props} style={style} />;
  };
}
```

```js
import { withStyles } from "./hoc/withStyles";

const Text = () => <p style={{ fontFamily: "Inter" }}>Hello world!</p>;
const StyledText = withStyles(Text);
```

In the Higher Order Component Pattern section, the example of `withStyles` higher order component and `Text` component. Since `withStyles` returns a new component with `style` props, should `Text` component receive the `props.style` as well? Otherwise the paragraph style inside `Text` component won't be updated.

I think the `Text` component should look like this.
```js
import { withStyles } from "./hoc/withStyles";

const Text = (props) => <p style={{ fontFamily: "Inter", ...props.style }}>Hello world!</p>;
const StyledText = withStyles(Text);
```

[https://javascriptpatterns.vercel.app/patterns/react-patterns/higher-order-component](https://javascriptpatterns.vercel.app/patterns/react-patterns/higher-order-component)