### PR TITLE
Change singleton pattern counter class

### DIFF
--- a/pages/patterns/design-patterns/singleton-pattern.mdx
+++ b/pages/patterns/design-patterns/singleton-pattern.mdx
@@ -51,9 +51,9 @@ let instance;
 class Counter {
   constructor() {
     if (instance) {
-      throw new Error("You can only create one instance!");
+      return instance;
     }
-    this.counter = counter;
+    this.counter = 0;
     instance = this;
   }
 
@@ -72,7 +72,7 @@ class Counter {
 
 // 2. Setting a variable equal to the the frozen newly instantiated object, by using the built-in `Object.freeze` method.
 // This ensures that the newly created instance is not modifiable.
-const singletonCounter = Object.freeze(new Counter());
+const singletonCounter = new Counter();
 
 // 3. Exporting the variable as the `default` value within the file to make it globally accessible.
 export default singletonCounter;


### PR DESCRIPTION
Hi, 
the counter class gave me the following error messages: 
- counter is not defined
- After initialization (this.counter = 0) "counter is read-only"

Removing Object.freeze and returning the instance in the constructor should resolve this issue.

Otherwise, as in the Objects example, counter can also be initiated outside the class: let counter = 0;
After that, however, the "this" keyword would have to be removed from the methods.

Thanks!