### PR TITLE
Update React compound pattern example

### DIFF
--- a/pages/patterns/react-patterns/compound-pattern.mdx
+++ b/pages/patterns/react-patterns/compound-pattern.mdx
@@ -131,21 +131,15 @@ export function FlyOut(props) {
   );
 }
 
-function Input(props) {
-  const { value, toggle } = React.useContext(FlyOutContext);
-
+function Input({ value, toggle }) {
   return <input onFocus={toggle} onBlur={toggle} value={value} {...props} />;
 }
 
-function List({ children }) {
-  const { open } = React.useContext(FlyOutContext);
-
+function List({ children, open }) {
   return open && <ul>{children}</ul>;
 }
 
-function ListItem({ children, value }) {
-  const { setValue } = React.useContext(FlyOutContext);
-
+function ListItem({ children, value, setValue }) {
   return <li onMouseDown={() => setValue(value)}>{children}</li>;
 }
 


### PR DESCRIPTION
In the second implementation of the compound pattern, since we are using the `React.Cuhildren.map` and `React.cloneElement`, I think we won't need to use `context` anymore and all the values are accessible by props.