### PR TITLE
Added private property #counter to allow internal edits with Object.freez()

### DIFF
--- a/pages/patterns/design-patterns/singleton-pattern.mdx
+++ b/pages/patterns/design-patterns/singleton-pattern.mdx
@@ -49,24 +49,25 @@ let instance;
 // 1. Creating the `Counter` class, which contains a `constructor`, `getInstance`, `getCount`, `increment` and `decrement` method.
 // Within the constructor, we check to make sure the class hasn't already been instantiated.
 class Counter {
+  #counter;
   constructor() {
     if (instance) {
       throw new Error("You can only create one instance!");
     }
-    this.counter = counter;
+    this.#counter = 0;
     instance = this;
   }
 
   getCount() {
-    return this.counter;
+    return this.#counter;
   }
 
   increment() {
-    return ++this.counter;
+    return ++this.#counter;
   }
 
   decrement() {
-    return --this.counter;
+    return --this.#counter;
   }
 }
 


### PR DESCRIPTION
For data properties of a frozen object, their values cannot be changed since the `writable` and `configurable` attributes are set to `false`. 

If we try to use the `increment()` or `decrement()` methods with `Object.freez()`, we get a TypeError says : `Cannot assign to read only property 'counter' of object '#<Counter>' at Counter.increment"`

[Private properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_properties) do not have the concept of property descriptors. Freezing an object with private properties does not prevent the values of these private properties from being changed.

In my request, I've added the `#counter` property as private property. Now we can use the `increment()` and `decrement()` methods with `Object.freez()` with no errors.