### PR TITLE
Update compound-pattern.mdx. Remove Context API.

### DIFF
--- a/pages/patterns/react-patterns/compound-pattern.mdx
+++ b/pages/patterns/react-patterns/compound-pattern.mdx
@@ -132,19 +132,17 @@ export function FlyOut(props) {
 }
 
 function Input(props) {
-  const { value, toggle } = React.useContext(FlyOutContext);
+  const { value, toggle } = props;
 
   return <input onFocus={toggle} onBlur={toggle} value={value} {...props} />;
 }
 
-function List({ children }) {
-  const { open } = React.useContext(FlyOutContext);
+function List({ children, open }) {
 
   return open && <ul>{children}</ul>;
 }
 
-function ListItem({ children, value }) {
-  const { setValue } = React.useContext(FlyOutContext);
+function ListItem({ children, value, setValue }) {
 
   return <li onMouseDown={() => setValue(value)}>{children}</li>;
 }


### PR DESCRIPTION
Since we are using `React.Children.map`  with `React.cloneElement`, we now access all the state through `props`. Context API is not valid here.